### PR TITLE
Use Percentage Difference When Comparing

### DIFF
--- a/.luaurc
+++ b/.luaurc
@@ -1,5 +1,5 @@
 {
     "aliases": {
-        "Bench": "src"
+        "Bench": "./src/"
     }
 }

--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ Comparing against Table Insert...
 
 Name: Length Insert
     Speed: [seconds]
-        Avg:    +3.178e-8  (+28.5%)
-        Max:    +3.000e-6  (+54.5%)
-        Total:  +6.509e-5  (+28.5%)
+        Avg:    +2.451e-8  (+18.2%)
+        Max:    -8.000e-7  (-4.3%)
+        Total:  +5.020e-5  (+18.2%)
     Memory: [kB]
-        Avg:    -4.887e-4  (-11.1%)
-        Total:  -1         (-11.1%)
+        Avg:    -4.882e-4  (-3.2%)
+        Total:  -1         (-3.2%)
 ]]
 ```
 

--- a/src/Compare.luau
+++ b/src/Compare.luau
@@ -8,19 +8,23 @@ type BenchCompareData = Variant.BenchCompareData
 type BenchCompareMetric = Variant.BenchCompareMetric
 type SimpleBenchMetric = Variant.SimpleBenchMetric
 
+local function percentageDifference(first: number, second: number)
+	return 100 * (second - first) / ((second + first) / 2)
+end
+
 -- higher value means worse
 local function metricPerc(
 	first: SimpleBenchMetric,
 	second: SimpleBenchMetric,
 	new: SimpleBenchMetric
 )
-	new.Total = 100 * (second.Total - first.Total) / first.Total
-	new.Average = 100 * (second.Average - first.Average) / first.Average
-	new.Minimum = 100 * (second.Minimum - first.Minimum) / first.Minimum
-	new.Maximum = 100 * (second.Maximum - first.Maximum) / first.Maximum
-	new.Low = 100 * (second.Low - first.Low) / first.Low
-	new.Median = 100 * (second.Median - first.Median) / first.Median
-	new.High = 100 * (second.High - first.High) / first.High
+	new.Total = percentageDifference(first.Total, second.Total)
+	new.Average = percentageDifference(first.Average, second.Average)
+	new.Minimum = percentageDifference(first.Minimum, second.Minimum)
+	new.Maximum = percentageDifference(first.Maximum, second.Maximum)
+	new.Low = percentageDifference(first.Low, second.Low)
+	new.Median = percentageDifference(first.Median, second.Median)
+	new.High = percentageDifference(first.High, second.High)
 end
 
 -- higher value means worse
@@ -85,6 +89,8 @@ return function(self: BenchData, ...: BenchData): BenchCompareData
 			},
 		}
 
+		-- How does v's performance compare to self's
+		-- Is v faster than or slower than self? (+ = faster, - = slower)
 		metricPerc(self.Speed, v.Speed, value.Speed.Percentage)
 		metricPerc(self.Memory, v.Memory, value.Memory.Percentage)
 


### PR DESCRIPTION
Prior versions used percentage error under the incorrect assumption that there is a "correct" value.  This PR rectifies the mistake, which slightly changes the percentages displayed recorded.